### PR TITLE
fix: EmitNilRecords option now distinguishes between structs and primitive types

### DIFF
--- a/internal/templates/stdlib/queryCode.tmpl
+++ b/internal/templates/stdlib/queryCode.tmpl
@@ -14,7 +14,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 	var {{.Ret.Name}} {{.Ret.Type}}
 	{{- end}}
 	err := row.Scan({{.Ret.Scan}})
-{{- if $.EmitNilRecords}}
+{{- if and $.EmitNilRecords .Ret.IsStruct }}
     if err != nil && errors.Is(err, sql.ErrNoRows) {
         return nil, nil
     }


### PR DESCRIPTION
I wanted to add endtoend test but it seems like those tests need specific wasm file url's to work properly, and they only work in sqlc's main repository. So, I tested this manually, and it seems to be working correctly.

![image](https://github.com/user-attachments/assets/0539cb42-2439-4c65-947c-1beb2a364352)
