### PR TITLE
fix: do not add pointer to slice arguments

### DIFF
--- a/internal/query.go
+++ b/internal/query.go
@@ -112,7 +112,7 @@ func (v QueryValue) TypeName() string {
 
 func (v *QueryValue) DefineType() string {
 	t := v.Type()
-	if v.IsPointer() && !strings.HasPrefix(t, "[]") {
+	if v.IsPointer() {
 		return "*" + t
 	}
 	return t

--- a/internal/query.go
+++ b/internal/query.go
@@ -10,14 +10,14 @@ import (
 )
 
 type QueryValue struct {
-	Emit           bool
-	EmitPointer    bool
-	EmitNilRecords bool
-	Name           string
-	DBName         string // The name of the field in the database. Only set if Struct==nil.
-	Struct         *Struct
-	Typ            string
-	SQLDriver      opts.SQLDriver
+	Emit                     bool
+	EmitPointer              bool
+	EmitPointerForNonStructs bool
+	Name                     string
+	DBName                   string // The name of the field in the database. Only set if Struct==nil.
+	Struct                   *Struct
+	Typ                      string
+	SQLDriver                opts.SQLDriver
 
 	// Column is kept so late in the generation process around to differentiate
 	// between mysql slices and pg arrays
@@ -33,7 +33,7 @@ func (v QueryValue) IsStruct() bool {
 }
 
 func (v QueryValue) IsPointer() bool {
-	return v.EmitNilRecords || (v.EmitPointer && v.Struct != nil)
+	return v.EmitPointerForNonStructs || (v.EmitPointer && v.Struct != nil)
 }
 
 func (v QueryValue) isEmpty() bool {

--- a/internal/query.go
+++ b/internal/query.go
@@ -112,7 +112,7 @@ func (v QueryValue) TypeName() string {
 
 func (v *QueryValue) DefineType() string {
 	t := v.Type()
-	if v.IsPointer() {
+	if v.IsPointer() && !strings.HasPrefix(t, "[]") {
 		return "*" + t
 	}
 	return t

--- a/internal/result.go
+++ b/internal/result.go
@@ -246,7 +246,7 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 				Typ:            goType(req, options, p.Column),
 				SQLDriver:      sqlpkg,
 				Column:         p.Column,
-				EmitNilRecords: options.EmitNilRecords,
+				EmitNilRecords: false,
 			}
 		} else if len(query.Params) >= 1 {
 			var cols []goColumn
@@ -269,7 +269,7 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 				Struct:         s,
 				SQLDriver:      sqlpkg,
 				EmitPointer:    options.EmitParamsStructPointers,
-				EmitNilRecords: options.EmitNilRecords,
+				EmitNilRecords: false,
 			}
 
 			// if query params is 2, and query params limit is 4 AND this is a copyfrom, we still want to emit the query's model

--- a/internal/result.go
+++ b/internal/result.go
@@ -241,12 +241,11 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 		if len(query.Params) == 1 && qpl != 0 {
 			p := query.Params[0]
 			gq.Arg = QueryValue{
-				Name:           escape(paramName(p)),
-				DBName:         p.Column.GetName(),
-				Typ:            goType(req, options, p.Column),
-				SQLDriver:      sqlpkg,
-				Column:         p.Column,
-				EmitNilRecords: false,
+				Name:      escape(paramName(p)),
+				DBName:    p.Column.GetName(),
+				Typ:       goType(req, options, p.Column),
+				SQLDriver: sqlpkg,
+				Column:    p.Column,
 			}
 		} else if len(query.Params) >= 1 {
 			var cols []goColumn
@@ -264,12 +263,11 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 				return nil, err
 			}
 			gq.Arg = QueryValue{
-				Emit:           true,
-				Name:           "arg",
-				Struct:         s,
-				SQLDriver:      sqlpkg,
-				EmitPointer:    options.EmitParamsStructPointers,
-				EmitNilRecords: false,
+				Emit:        true,
+				Name:        "arg",
+				Struct:      s,
+				SQLDriver:   sqlpkg,
+				EmitPointer: options.EmitParamsStructPointers,
 			}
 
 			// if query params is 2, and query params limit is 4 AND this is a copyfrom, we still want to emit the query's model
@@ -284,11 +282,11 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 			name := columnName(c, 0)
 			name = strings.Replace(name, "$", "_", -1)
 			gq.Ret = QueryValue{
-				Name:           escape(name),
-				DBName:         name,
-				Typ:            goType(req, options, c),
-				SQLDriver:      sqlpkg,
-				EmitNilRecords: options.EmitNilRecords,
+				Name:                     escape(name),
+				DBName:                   name,
+				Typ:                      goType(req, options, c),
+				SQLDriver:                sqlpkg,
+				EmitPointerForNonStructs: options.EmitNilRecords,
 			}
 		} else if putOutColumns(query) {
 			var gs *Struct
@@ -334,12 +332,12 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 				emit = true
 			}
 			gq.Ret = QueryValue{
-				Emit:           emit,
-				Name:           "i",
-				Struct:         gs,
-				SQLDriver:      sqlpkg,
-				EmitPointer:    options.EmitResultStructPointers,
-				EmitNilRecords: options.EmitNilRecords,
+				Emit:                     emit,
+				Name:                     "i",
+				Struct:                   gs,
+				SQLDriver:                sqlpkg,
+				EmitPointer:              options.EmitResultStructPointers,
+				EmitPointerForNonStructs: options.EmitNilRecords,
 			}
 		}
 


### PR DESCRIPTION
IsPointer in combination with EmitNilRecords caused pointer slice arguments, which is not what expected.

```go
// Before
func (q *Queries) Foo(ctx context.Context, bars *[]string)...
// After
func (q *Queries) Foo(ctx context.Context, bars []string)...
```